### PR TITLE
Harden rule logging

### DIFF
--- a/packages/gbnf/javascript/src/builder/gbnf-rule.test.ts
+++ b/packages/gbnf/javascript/src/builder/gbnf-rule.test.ts
@@ -9,90 +9,200 @@ import {
 } from './template-tags.js';
 
 describe('GBNFRule', () => {
-  test('it logs', () => {
-    const rule = $`foo`;
-    expect(rule.log()).toEqual('foo')
-  });
+  describe('logging', () => {
+    test('it logs', () => {
+      const rule = $`foo`;
+      expect(rule.log()).toEqual('foo')
+    });
 
-  test('it logs a _ string', () => {
-    const rule = _`"foo"`;
-    expect(rule.log()).toEqual('foo')
-  });
+    test('it logs a _ string', () => {
+      const rule = _`"foo"`;
+      expect(rule.log()).toEqual('foo')
+    });
 
-  test('it logs two paths', () => {
-    const rule = _`${$`foo`} | ${$`bar`}`;
-    expect(rule.log()).toEqual('foo\nbar')
-  });
+    test('it logs two paths', () => {
+      const rule = _`${$`foo`} | ${$`bar`}`;
+      expect(rule.log({ shuffle: false })).toEqual(['foo', 'bar'].join('\n'))
+    });
 
-  test('it logs overlapping paths', () => {
-    const rule = _`${$`foo`} | ${$`f`}`;
-    expect(rule.log()).toEqual('f\nfoo')
-  });
+    test('it logs overlapping paths', () => {
+      const rule = _`${$`foo`} | ${$`f`}`;
+      expect(rule.log()).toEqual('f\nfoo')
+    });
 
-  test('turns ranges into x', () => {
-    const rule = _`[a-z]`;
-    expect(rule.log()).toEqual('x')
-  });
+    test('turns ranges into x', () => {
+      const rule = _`[a-z]`;
+      expect(rule.log()).toEqual('x')
+    });
 
-  test('turns multiple ranges into x', () => {
-    const rule = _`[a-z][a-z][a-z]`;
-    expect(rule.log()).toEqual('xxx')
-  });
+    test('turns multiple ranges into x', () => {
+      const rule = _`[a-z][a-z][a-z]`;
+      expect(rule.log()).toEqual('xxx')
+    });
 
-  test('it handles a range and a string', () => {
-    const rule = _`[a-e] | "foo"`;
-    expect(rule.log()).toEqual('x\nfoo')
-  });
+    test('it handles a range and a string', () => {
+      const rule = _`[a-e] | "foo"`;
+      expect(rule.log({ shuffle: false })).toEqual(['x', 'foo'].join('\n'))
+    });
 
-  test('it handles an optional', () => {
-    const rule = _`"z" ([a-e]? | "foo")`;
-    expect(rule.log()).toEqual('z\nzx\nzfoo')
-  });
+    test('it handles an optional', () => {
+      const rule = _`"z" ([a-e]? | "foo")`;
+      expect(rule.log({ shuffle: false })).toEqual(['z', 'zx', 'zfoo'].join('\n'))
+    });
 
-  test('it handles an optional on a rule', () => {
-    const rule = _`"z" (("bar")? | "foo")`;
-    expect(rule.log()).toEqual('z\nzbar\nzfoo')
-  });
+    test('it handles an optional on a rule', () => {
+      const rule = _`"z" (("bar")? | "foo")`;
+      expect(rule.log({ shuffle: false })).toEqual(['z', 'zbar', 'zfoo'].join('\n'))
+    });
 
-  test('it handles a star', () => {
-    const rule = _`"z" ("y")*`;
-    expect(rule.log()).toEqual(['z', 'zy', 'zyy', 'zyyy'].join('\n'))
-  });
+    test('it handles a star', () => {
+      const rule = _`"z" ("y")*`;
+      expect(rule.log({ shuffle: false })).toEqual(['z', 'zy', 'zyy', 'zyyy'].join('\n'))
+    });
 
-  test('it handles a star wrapping a rule', () => {
-    const rule = _`"z" ([a-e] | "foo")*`;
-    expect(rule.log()).toEqual([
-      'z',
-      'zx',
-      'zxx',
-      'zxxx',
-      'zxxfoo',
-      'zxfoo',
-      'zxfoox',
-      'zxfoofoo',
-      'zfoo',
-      'zfoox',
-      'zfooxx',
-      'zfooxfoo',
-      'zfoofoo',
-      'zfoofoox',
-      'zfoofoofoo',
-    ].join('\n'))
-  });
+    test('it handles a star wrapping a rule', () => {
+      const rule = _`"z" ([a-e] | "foo")*`;
+      expect(rule.log({ shuffle: false })).toEqual([
+        'z',
+        'zx',
+        'zxx',
+        'zxxx',
+        'zxxfoo',
+        'zxfoo',
+        'zxfoox',
+        'zxfoofoo',
+        'zfoo',
+        'zfoox',
+        'zfooxx',
+        'zfooxfoo',
+        'zfoofoo',
+        'zfoofoox',
+        'zfoofoofoo',
+      ].join('\n'))
+    });
 
-  test('it handles a plus', () => {
-    const rule = _`"z" ("y")+`;
-    expect(rule.log()).toEqual([
-      'zy',
-      'zyy',
-      'zyyy',
-    ].join('\n'))
-  });
+    test('it handles a plus', () => {
+      const rule = _`"z" ("y")+`;
+      expect(rule.log()).toEqual([
+        'zy',
+        'zyy',
+        'zyyy',
+      ].join('\n'))
+    });
 
-  test('it handles a negative', () => {
-    const rule = _`"z" [^a-zA-Z]`;
-    expect(rule.log()).toEqual([
-      'z^',
-    ].join('\n'))
+    test('it handles a negative', () => {
+      const rule = _`"z" [^a-zA-Z]`;
+      expect(rule.log()).toEqual([
+        'z^',
+      ].join('\n'))
+    });
+
+    test('it handles alt rules', () => {
+      const rule = _`
+        ${_`"foo" | "bar" | "baz"`}
+      `;
+      expect(rule.log({ shuffle: false })).toEqual([
+        'foo',
+        'bar',
+        'baz',
+      ].join('\n'))
+    });
+
+    test('it limits to n possible rules', () => {
+      const rule = _`
+        ${_`
+          ${_`
+            "foo1"
+            | "foo2"
+          `} 
+          | "bar" 
+          | "baz"`
+        }
+        "z"
+        ${_`
+          ${_`
+            "foo1"
+            | "foo2"
+          `} 
+          | "bar" 
+          | "baz"`
+        }
+      `;
+      const allPossibibilities = [
+        'foo1zfoo1',
+        'foo1zfoo2',
+        'foo1zbar',
+        'foo1zbaz',
+        'foo2zfoo1',
+        'foo2zfoo2',
+        'foo2zbar',
+        'foo2zbaz',
+        'barzfoo1',
+        'barzfoo2',
+        'barzbar',
+        'barzbaz',
+        'bazzfoo1',
+        'bazzfoo2',
+        'bazzbar',
+        'bazzbaz',
+      ];
+      const n = 5;
+      const logs = rule.log({ n }).split('\n');
+      expect(logs.length).toBe(n);
+      logs.forEach(log => {
+        expect(allPossibibilities).toContain(log);
+      });
+    });
+
+    test('it handles max depth', () => {
+      const value = _`[a-z]`.key('value');
+      const repeating = _`
+          ","
+          value
+          repeating
+          `.key('repeating');
+      const rule = _`
+        value
+        repeating
+      `;
+      const n = 2;
+      const maxDepth = 10;
+      const logs = rule.log({
+        include: [value, repeating],
+        n,
+        maxDepth,
+      }).split('\n');
+      expect(logs.length).toBeLessThanOrEqual(n);
+
+      const allPossibibilities = [
+        Array(maxDepth / 2).fill('x,').join(''),
+      ];
+      logs.forEach(log => {
+        expect(allPossibibilities).toContain(log);
+      });
+    });
+
+    test('it handles infinite rules', () => {
+      const value = _`[a-z]`.key('value');
+      const repeating = _`
+          ","
+          value
+          ${_`"!"`.wrap('?')}
+          repeating
+          `.key('repeating');
+      const rule = _`
+        value
+        repeating
+      `;
+      const n = 3;
+      const logs = rule.log({
+        include: [value, repeating],
+        n,
+        maxDepth: Infinity,
+        maxRunTime: 10,
+      }).split('\n');
+      expect(logs.length).toBe(n);
+    });
+
   });
 });

--- a/packages/gbnf/javascript/src/builder/gbnf-rule.ts
+++ b/packages/gbnf/javascript/src/builder/gbnf-rule.ts
@@ -85,7 +85,18 @@ export class GBNFRule {
     return this.compile();
   }
 
-  log = (opts: Parameters<typeof this.compile>[0] = {}) => {
+  log = ({
+    shuffle = true,
+    n = Infinity,
+    maxDepth = 20,
+    maxRunTime = 50,
+    ...opts
+  }: {
+    shuffle?: boolean;
+    n?: number;
+    maxDepth?: number;
+    maxRunTime?: number;
+  } & Parameters<typeof this.compile>[0] = {}) => {
     let gbnf = this.compile(opts);
     gbnf = gbnf.replaceAll(/\((.*?)\)\*/g, '($1)? ($1)? ($1)?');
     gbnf = gbnf.replaceAll(/\((.*?)\)\+/g, '($1)  ($1)? ($1)?');
@@ -94,6 +105,7 @@ export class GBNFRule {
     class Node {
       char: string;
       terminal = false;
+      reachedMaxDepth = false;
       children: Node[] = [];
 
       constructor(char = '') {
@@ -103,23 +115,39 @@ export class GBNFRule {
     const parseState = GBNF(gbnf);
     const rootNode = new Node('');
 
-    function traverseParseState(currentNode: Node, parseState: ParseState) {
+    let remaining = n;
+    const start = performance.now();
+    let reachedMaximumRunTime = false;
+    function traverseParseState(currentNode: Node, parseState: ParseState, remainingDepth = maxDepth) {
+      if (performance.now() - start > maxRunTime) {
+        reachedMaximumRunTime = true;
+        return;
+      }
+      if (remainingDepth <= 0) {
+        currentNode.reachedMaxDepth = true;
+        remaining -= 1;
+        return;
+      }
       for (const rule of parseState) {
+        if (remaining <= 0) {
+          return;
+        }
         if (isRuleChar(rule)) {
           for (const value of rule.value) {
             const char = Array.isArray(value) ? 'x' : String.fromCodePoint(value);
             const nextNode = new Node(char);
             currentNode.children.push(nextNode);
-            traverseParseState(nextNode, parseState.add(Array.isArray(value) ? String.fromCodePoint(value[0]) : char));
+            traverseParseState(nextNode, parseState.add(Array.isArray(value) ? String.fromCodePoint(value[0]) : char), remainingDepth - 1);
           }
         } else if (isRuleCharExcluded(rule)) {
           for (const value of rule.value) {
             const char = Array.isArray(value) ? '^' : String.fromCodePoint(value);
             const nextNode = new Node(char);
             currentNode.children.push(nextNode);
-            traverseParseState(nextNode, parseState.add(Array.isArray(value) ? String.fromCodePoint(value[0] - 1) : char));
+            traverseParseState(nextNode, parseState.add(Array.isArray(value) ? String.fromCodePoint(value[0] - 1) : char), remainingDepth - 1);
           }
         } else if (isRuleEnd(rule)) {
+          remaining -= 1;
           currentNode.terminal = true;
         }
       }
@@ -129,10 +157,13 @@ export class GBNFRule {
 
     const result = new Set<string>();
     function traverse(node: Node, path = '') {
-      if (node.terminal) {
+      if (result.size >= n) {
+        return;
+      }
+      if (node.terminal || node.reachedMaxDepth || (reachedMaximumRunTime && node.children.length === 0)) {
         result.add(path);
       }
-      for (const child of node.children) {
+      for (const child of (shuffle ? shuffleSort(node.children) : node.children)) {
         traverse(child, path + child.char);
       }
     }
@@ -174,3 +205,9 @@ export class GBNFRule {
   };
 }
 
+function shuffleSort<T>(arr: T[]): T[] {
+  return arr
+    .map(value => ({ value, sort: Math.random(), }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value, }) => value);
+}


### PR DESCRIPTION
- Ensure infinite rule definitions have a maximum recursion depth
- Ensure long rules have a maximum runtime cut off
- Allow for specifying max number of rules to show
- Allow for randomly shuffling the rules that are printed