### PR TITLE
[Contort] Transformers.js additional input options

### DIFF
--- a/packages/contort/dev/browser/transformersjs/index.html
+++ b/packages/contort/dev/browser/transformersjs/index.html
@@ -26,6 +26,7 @@
     pre {
       padding: 1em;
       background-color: #f4f4f4;
+
       border: 1px solid #ddd;
       border-radius: 5px;
       margin: 1em 0;

--- a/packages/contort/dev/browser/transformersjs/index.ts
+++ b/packages/contort/dev/browser/transformersjs/index.ts
@@ -1,54 +1,46 @@
 import {
   pipeline,
   env,
+  AutoTokenizer,
+  AutoModelForCausalLM,
   TextGenerationPipeline,
 } from '@xenova/transformers';
 env.allowRemoteModels = true;
 env.allowLocalModels = false;
-import Contortionist from '../../../src/index.js';
-import { _ } from 'gbnf/builder';
+import Contort from '../../../src/index.js';
 
-// Specify a custom location for models (defaults to '/models/').
-// env.localModelPath = '/';
-const model = await pipeline('text-generation', 'Xenova/gpt2');
-const contort = new Contortionist({
-  model,
-  grammar: _`
-    [-._a-zA-Z0-9 \\n]+
-  `,
+const modelId = 'Xenova/gpt2';
+
+
+const contort2 = new Contort({
+  model: {
+    protocol: 'transformers.js',
+    model: AutoModelForCausalLM.from_pretrained(modelId),
+    tokenizer: AutoTokenizer.from_pretrained(modelId),
+  }
 });
-
-const result = await contort.execute('What is your name?\n', {
-  max_new_tokens: 1,
-});
-console.log(result);
+const pipelineResult = await contort2.execute('Write me a list of numbers:\n');
 
 
-// // import chess from '../grammars/chess.gbnf?raw';
-// import json from '../grammars/json.gbnf?raw';
+const contort = new Contort({ model: pipeline('text-generation', modelId) });
+const tokResult = await contort.execute('Write me a list of numbers:\n');
 
-// // const model = pipeline('text-generation', 'Xenova/phi-1_5_dev', {
-// const model = pipeline('text-generation', 'Xenova/gpt2', {
-//   progress_callback: console.log,
+console.log(pipelineResult, '******', tokResult);
+
+
+// contort
+
+
+// console.log('tokenizer', tokenizer)
+
+// const inputs = tokenizer('foo');
+// console.log('inputs', inputs)
+// const outputs = await model.generate(inputs.input_ids, {
+//   max_new_tokens: 5,
+// }, undefined, {
+//   inputs_attention_mask: inputs.attention_mask,
 // });
+// const outputText = tokenizer.batch_decode(outputs, { skip_special_tokens: false });
+// console.log('outputs!', outputText);
+// debugger;
 
-
-// const contort = new Contortionist({
-//   model,
-//   // grammar: `root ::= "foo" | "bar"`,
-//   grammar: json,
-//   // grammar: `root ::= "1. "`,
-//   // grammar: `root ::= " ."`,
-// });
-
-// const output = await contort.execute('Describe the state of the world in JSON\n', {
-//   callback: ({ partial, }) => console.log(partial),
-//   llmOpts: {
-//     max_new_tokens: 100,
-//     // num_beams: 5,
-//     no_repeat_ngram_size: 2,
-//     early_stopping: true,
-//   },
-// });
-// console.log('----- complete ------');
-// console.log('output', output);

--- a/packages/contort/dev/browser/transformersjs/old.ts
+++ b/packages/contort/dev/browser/transformersjs/old.ts
@@ -1,0 +1,14 @@
+import {
+  pipeline,
+  env,
+} from '@xenova/transformers';
+env.allowRemoteModels = false;
+env.allowLocalModels = true;
+
+// Specify a custom location for models (defaults to '/models/').
+env.localModelPath = '/';
+const model = await pipeline('text-generation', 'phi-1_5_dev');
+
+const result = await model('Write me a list of numbers:\n');
+console.log('result', result);
+

--- a/packages/contort/dev/browser/transformersjs/worker.js
+++ b/packages/contort/dev/browser/transformersjs/worker.js
@@ -1,0 +1,187 @@
+import {
+  AutoTokenizer,
+  AutoModelForCausalLM,
+  TextStreamer,
+  StoppingCriteria,
+  pipeline,
+} from '@xenova/transformers';
+// import { contort } from '../../../../contort/src/index.js';
+
+class CallbackTextStreamer extends TextStreamer {
+  constructor(tokenizer, cb) {
+    super(tokenizer, {
+      skip_prompt: true,
+      skip_special_tokens: true,
+    });
+    this.cb = cb;
+  }
+
+  on_finalized_text(text) {
+    this.cb(text);
+  }
+}
+
+class InterruptableStoppingCriteria extends StoppingCriteria {
+  constructor() {
+    super();
+    this.interrupted = false;
+  }
+
+  interrupt() {
+    this.interrupted = true;
+  }
+
+  reset() {
+    this.interrupted = false;
+  }
+
+  _call(input_ids, scores) {
+    return new Array(input_ids.length).fill(this.interrupted);
+  }
+}
+
+const stopping_criteria = new InterruptableStoppingCriteria();
+
+async function hasFp16() {
+  try {
+    const adapter = await navigator.gpu.requestAdapter();
+    return adapter.features.has('shader-f16');
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * This class uses the Singleton pattern to ensure that only one instance of the model is loaded.
+ */
+class TextGenerationPipeline {
+  static model_id = null;
+  static model = null;
+  static tokenizer = null;
+  static streamer = null;
+
+  static async getInstance(progress_callback = null) {
+    // Choose the model based on whether fp16 is available
+    // this.model_id ??= (await hasFp16())
+    //   ? 'Xenova/Phi-3-mini-4k-instruct_fp16'
+    //   : 'Xenova/Phi-3-mini-4k-instruct';
+    this.model_id = 'Xenova/gpt2';
+
+
+    this.tokenizer ??= AutoTokenizer.from_pretrained(this.model_id, {
+      legacy: true,
+      progress_callback,
+    });
+
+    this.model ??= AutoModelForCausalLM.from_pretrained(this.model_id, {
+      dtype: 'q4',
+      device: 'webgpu',
+      use_external_data_format: true,
+      progress_callback,
+    });
+
+    return Promise.all([this.tokenizer, this.model]);
+  }
+}
+
+async function generate(messages) {
+  console.log('generate')
+  // Retrieve the text-generation pipeline.
+  const [tokenizer, model] = await TextGenerationPipeline.getInstance();
+
+  const inputs = tokenizer.apply_chat_template(messages, {
+    add_generation_prompt: true,
+    return_dict: true,
+  });
+
+  let startTime;
+  let numTokens = 0;
+  const cb = (output) => {
+    startTime ??= performance.now();
+
+    let tps;
+    if (numTokens++ > 0) {
+      tps = numTokens / (performance.now() - startTime) * 1000;
+    }
+    self.postMessage({
+      status: 'update',
+      output, tps, numTokens,
+    });
+  }
+
+  const streamer = new CallbackTextStreamer(tokenizer, cb);
+
+  // Tell the main thread we are starting
+  self.postMessage({ status: 'start' });
+
+  // contort({
+  //   model,
+  // });
+
+  const outputs = await model.generate({
+    ...inputs,
+    max_new_tokens: 512,
+    streamer,
+    stopping_criteria,
+  });
+  const outputText = tokenizer.batch_decode(outputs, { skip_special_tokens: false });
+
+  // Send the output back to the main thread
+  self.postMessage({
+    status: 'complete',
+    output: outputText,
+  });
+}
+
+async function load() {
+  console.log('load')
+  self.postMessage({
+    status: 'loading',
+    data: 'Loading model...'
+  });
+
+  // Load the pipeline and save it for future use.
+  const [tokenizer, model] = await TextGenerationPipeline.getInstance(x => {
+    // We also add a progress callback to the pipeline so that we can
+    // track model loading.
+    self.postMessage(x);
+  });
+
+  self.postMessage({
+    status: 'loading',
+    data: 'Compiling shaders and warming up model...'
+  });
+
+  // Run model with dummy input to compile shaders
+  const inputs = tokenizer('a');
+  console.log(inputs.input_ids.data[0])
+  await model.generate({ ...inputs, max_new_tokens: 1 });
+  // console.log('YES')
+  self.postMessage({ status: 'ready' });
+}
+// Listen for messages from the main thread
+self.addEventListener('message', async (e) => {
+  const { type, data } = e.data;
+  console.log(type, data)
+
+  switch (type) {
+    case 'load':
+      load();
+      break;
+
+    case 'generate':
+      stopping_criteria.reset();
+      generate(data);
+      break;
+
+    case 'interrupt':
+      stopping_criteria.interrupt();
+      break;
+
+    case 'reset':
+      stopping_criteria.reset();
+      break;
+  }
+});
+
+

--- a/packages/contort/src/llms/js-llms/transformersjs/transformersjs-llm.test.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/transformersjs-llm.test.ts
@@ -30,7 +30,7 @@ describe('TransformersJSLLM', () => {
   test('it initializes', () => {
     const mockPipeline = makeMockTextGenerationPipeline();
     const llm = new TransformersJSLLM(mockPipeline);
-    expect(llm.pipeline).toBe(mockPipeline);
+    expect(llm.modelDefinition).toBe(mockPipeline);
   });
   // max_new_tokens: n,
 });

--- a/packages/contort/src/llms/js-llms/transformersjs/transformersjs-llm.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/transformersjs-llm.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import {
+import type {
   PreTrainedModel,
   PreTrainedTokenizer,
 } from "@xenova/transformers";

--- a/packages/contort/src/llms/js-llms/transformersjs/transformersjs-llm.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/transformersjs-llm.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import type {
+import {
   PreTrainedModel,
   PreTrainedTokenizer,
-  TextGenerationPipeline,
 } from "@xenova/transformers";
 import { GrammarLogitsProcessor, } from "./grammar-logits-processor.js";
 import type {
@@ -11,17 +10,53 @@ import type {
   TransformersJSOpts,
   TokenizeFn,
   TransformersJSExecuteOptions,
+  TransformersJSModelDefinition,
 } from "./types.js";
 import { GrammarParser, } from "../../../utils/grammar-parser/index.js";
 import { GetToken, } from "../../../utils/grammar-parser/types.js";
+import { isModelDefinitionPipeline, isTextGenerationPipeline, } from "./type-guards.js";
 
 // export const DEFAULT_TEMPERATURE = 0.5;
 export const DEFAULT_TEMPERATURE = 0.0;
 
 export class TransformersJSLLM {
   grammarParser: GrammarParser;
-  constructor(public pipeline: TextGenerationPipeline) {
-    const tokenizer = pipeline.tokenizer as PreTrainedTokenizer;
+  get tokenizer(): Promise<PreTrainedTokenizer> {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    return new Promise<PreTrainedTokenizer>(async (resolve) => {
+      const modelDefinition = await this.modelDefinition;
+      if (isTextGenerationPipeline(modelDefinition)) {
+        resolve(modelDefinition.tokenizer);
+      } else if (isModelDefinitionPipeline(modelDefinition)) {
+        const pipeline = await modelDefinition.pipeline;
+        resolve(pipeline.tokenizer);
+      } else {
+        resolve(modelDefinition.tokenizer);
+      }
+    });
+  }
+
+  get model(): Promise<PreTrainedModel> {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    return new Promise<PreTrainedModel>(async (resolve) => {
+      const modelDefinition = await this.modelDefinition;
+      if (isTextGenerationPipeline(modelDefinition)) {
+        resolve(modelDefinition.model);
+      } else if (isModelDefinitionPipeline(modelDefinition)) {
+        const pipeline = await modelDefinition.pipeline;
+        resolve(pipeline.model);
+      } else {
+        resolve(modelDefinition.model);
+      }
+    });
+  }
+
+  constructor(public modelDefinition: TransformersJSModelDefinition) {
+    void this.setup();
+  }
+
+  setup = async () => {
+    const tokenizer = await this.tokenizer;
     const stopTokenId = tokenizer.model.convert_tokens_to_ids([tokenizer.getToken('eos_token'),])[0];
     const vocabSize = tokenizer.model.vocab.length;
     const getToken: GetToken = tokenId => tokenizer.decode([tokenId,]);
@@ -30,7 +65,6 @@ export class TransformersJSLLM {
       vocabSize,
       stopTokenId,
       getToken,
-      // getDecodedByteForChar,
     });
   };
 
@@ -41,7 +75,7 @@ export class TransformersJSLLM {
     llmOpts = {},
     // signal,
   }: TransformersJSExecuteOptions) {
-    const tokenizer = this.pipeline.tokenizer as PreTrainedTokenizer;
+    const [model, tokenizer,] = await Promise.all([this.model, this.tokenizer,]);
     const callbackFunction = callback ? (beams: Beam[]) => {
       for (const beam of beams) {
         const outputTokenIds = beam.output_token_ids;
@@ -63,12 +97,14 @@ export class TransformersJSLLM {
       this.grammarParser.initialize(grammar);
     }
     const logitsProcessor = grammar ? new GrammarLogitsProcessor(prompt, this.grammarParser, tokenizer) : undefined;
+
+    // The type definitions for Transformers.js functions appear as anys, which get reported as bugs
     const { input_ids, attention_mask, } = (tokenizer as TokenizeFn)(prompt);
 
-    // The type definitions for Transformers.js objects appear as anys, which get reported as bugs
-    const model = this.pipeline.model as PreTrainedModel;
+    // The type definitions for Transformers.js functions appear as anys, which get reported as bugs
+    const generate = model.generate.bind(model) as GenerateFn;
 
-    const outputTokenIds = await (model.generate as GenerateFn)(input_ids, generate_kwargs, logitsProcessor, {
+    const outputTokenIds = await generate(input_ids, generate_kwargs, logitsProcessor, {
       inputs_attention_mask: attention_mask,
     });
     const decoded = tokenizer.decode(outputTokenIds[0], {

--- a/packages/contort/src/llms/js-llms/transformersjs/type-guards.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/type-guards.ts
@@ -1,0 +1,27 @@
+import {
+  TextGenerationPipeline,
+} from "@xenova/transformers";
+import type {
+  BaseModelDefinition,
+  ModelDefinitionModelAndTokenizer,
+  ModelDefinitionPipeline,
+} from "./types.js";
+
+export const isTextGenerationPipeline = (model: unknown): model is TextGenerationPipeline => {
+  // TODO: Can this be tightened without relying on "instance"?
+  // If so, we could remove the hard dependency on transformers at runtime and load it dynamically
+  return model instanceof TextGenerationPipeline;
+};
+
+const isModelDefinitionTransformersJS = (model: unknown): model is BaseModelDefinition => {
+  return typeof model === 'object' && 'protocol' in model && model.protocol === 'transformers.js';
+};
+
+export const isModelDefinitionPipeline = (model: unknown): model is ModelDefinitionPipeline => {
+  return isModelDefinitionTransformersJS(model) && 'pipeline' in model;
+};
+
+export const isModelDefinitionModelAndTokenizer = (model: unknown): model is ModelDefinitionModelAndTokenizer => {
+  return isModelDefinitionTransformersJS(model) && 'model' in model && 'tokenizer' in model;
+};
+

--- a/packages/contort/src/llms/js-llms/transformersjs/type-guards.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/type-guards.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TextGenerationPipeline,
 } from "@xenova/transformers";
 import type {
@@ -10,7 +10,8 @@ import type {
 export const isTextGenerationPipeline = (model: unknown): model is TextGenerationPipeline => {
   // TODO: Can this be tightened without relying on "instance"?
   // If so, we could remove the hard dependency on transformers at runtime and load it dynamically
-  return model instanceof TextGenerationPipeline;
+  // return model instanceof TextGenerationPipeline;
+  return typeof model === 'function';
 };
 
 const isModelDefinitionTransformersJS = (model: unknown): model is BaseModelDefinition => {

--- a/packages/contort/src/llms/js-llms/transformersjs/types.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/types.ts
@@ -1,5 +1,7 @@
-import type {
+import {
   Tensor as _Tensor,
+  PreTrainedModel,
+  PreTrainedTokenizer,
   TextGenerationConfig,
   TextGenerationPipeline,
 } from "@xenova/transformers";
@@ -83,4 +85,19 @@ export interface GenerationOutput {
 
 export type OutputTokenIds = number[][];
 
-export type TransformersJSModelDefinition = TextGenerationPipeline;
+export interface BaseModelDefinition {
+  protocol: 'transformers.js';
+}
+
+export type Pipeline = TextGenerationPipeline | Promise<TextGenerationPipeline>;
+
+export interface ModelDefinitionPipeline extends BaseModelDefinition {
+  pipeline: Pipeline;
+}
+
+export interface ModelDefinitionModelAndTokenizer extends BaseModelDefinition {
+  model: PreTrainedModel | Promise<PreTrainedModel>;
+  tokenizer: PreTrainedTokenizer | Promise<PreTrainedTokenizer>;
+}
+
+export type TransformersJSModelDefinition = Pipeline | ModelDefinitionPipeline | ModelDefinitionModelAndTokenizer;

--- a/packages/contort/src/llms/js-llms/transformersjs/types.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Tensor as _Tensor,
   PreTrainedModel,
   PreTrainedTokenizer,

--- a/packages/contort/src/type-guards.ts
+++ b/packages/contort/src/type-guards.ts
@@ -9,6 +9,11 @@ import type {
 import type {
   WebLLMModelDefinition,
 } from "./llms/js-llms/web-llm/types.js";
+import {
+  isModelDefinitionModelAndTokenizer,
+  isModelDefinitionPipeline,
+  isTextGenerationPipeline,
+} from "./llms/js-llms/transformersjs/type-guards.js";
 
 export function modelIsProtocolDefinition<M extends ModelProtocol>(model: ModelDefinition<M>): model is ModelProtocolDefinition<M> {
   return typeof model === 'object' && 'endpoint' in model && model.endpoint !== undefined;
@@ -19,8 +24,7 @@ export function isProtocol<M extends ModelProtocol>(protocol: M, model: ModelPro
 }
 
 export function isTransformersJSModelDefinition<M extends ModelProtocol>(model: ModelDefinition<M>): model is TransformersJSModelDefinition {
-  // TODO: Can this be tightened without relying on "instance"?
-  return typeof model === 'function';
+  return isTextGenerationPipeline(model) || isModelDefinitionPipeline(model) || isModelDefinitionModelAndTokenizer(model);
 };
 
 export function isWebLLMModelDefinition<M extends ModelProtocol>(model: ModelDefinition<M>): model is WebLLMModelDefinition {

--- a/packages/contort/src/types.ts
+++ b/packages/contort/src/types.ts
@@ -33,7 +33,6 @@ export interface ModelProtocolDefinition<M extends ModelProtocol> {
 
 export type ModelDefinition<M extends ModelProtocol | undefined> =
   TransformersJSModelDefinition
-  | Promise<TransformersJSModelDefinition>
   | WebLLMModelDefinition
   | Promise<WebLLMModelDefinition>
   | ModelProtocolDefinition<M>;
@@ -60,7 +59,7 @@ export type LLMOpts<M extends ModelProtocol> =
   : Record<string, unknown>;
 
 export interface ConstructorOptions<M extends ModelProtocol | undefined = undefined> {
-  grammar?: Grammar | GBNFRule;
+  grammar?: Grammar;
   model?: ModelDefinition<M>;
 }
 

--- a/packages/contort/src/types.ts
+++ b/packages/contort/src/types.ts
@@ -1,6 +1,3 @@
-import type {
-  GBNFRule,
-} from "gbnf/builder";
 import {
   type LlamaCPPPrompt,
   type LlamaCPPResponse,


### PR DESCRIPTION
Update the Transformers.js LLM adapter to support operations on top of both TextGenerationPipeline (`pipeline` import) as well as independently loaded PreTrainedModel and PreTrainedTokenizer objects.

The latter is required to work with some cutting edge models, for example Phi-3.