### PR TITLE
Update GBNF to accept a GBNF rule as input

### DIFF
--- a/packages/gbnf/javascript/package.json
+++ b/packages/gbnf/javascript/package.json
@@ -26,9 +26,11 @@
   "scripts": {
     "clean": "wireit",
     "lint": "wireit",
-    "test:unit": "wireit",
     "test": "wireit",
+    "test:unit": "wireit",
     "test:integration": "wireit",
+    "test:unit:watch": "wireit",
+    "test:integration:watch": "wireit",
     "build": "wireit",
     "build:check": "wireit",
     "build:esm": "wireit",
@@ -38,6 +40,9 @@
     "clean": {
       "command": "rimraf ./dist"
     },
+    "test:unit:watch": {
+      "command": "vitest --config ./vitest.config.unit.ts --hideSkippedTests"
+    },
     "test:unit": {
       "command": "vitest --config ./vitest.config.unit.ts run"
     },
@@ -46,6 +51,9 @@
     },
     "test:integration": {
       "command": "vitest --config ./vitest.config.integration.ts run"
+    },
+    "test:integration:watch": {
+      "command": "vitest --config ./vitest.config.integration.ts --hideSkippedTests"
     },
     "lint": {
       "command": "eslint -c .eslintrc.cjs src --ext .ts"

--- a/packages/gbnf/javascript/src/gbnf.test.ts
+++ b/packages/gbnf/javascript/src/gbnf.test.ts
@@ -12,6 +12,7 @@ import { Graph, } from './grammar-graph/graph.js';
 import * as _Graph from './grammar-graph/graph.js';
 import { ParseState, } from './grammar-graph/parse-state.js';
 import * as _ParseState from './grammar-graph/parse-state.js';
+import { _ } from './builder/template-tags.js';
 
 vi.mock('./grammar-graph/parse-state.js', async () => {
   const actual = await vi.importActual('./grammar-graph/parse-state.js') as typeof _ParseState;
@@ -90,7 +91,7 @@ describe('GBNF', () => {
         rules = rules;
         symbolIds = symbolIds;
       }
-      return new MockRulesBuilder() as RulesBuilder;
+      return new MockRulesBuilder() as unknown as RulesBuilder;
     });
     class MockGraph { add = vi.fn().mockImplementation(() => 'foo') }
     const mockGraph = new MockGraph();
@@ -106,5 +107,33 @@ describe('GBNF', () => {
     expect(Graph).toHaveBeenCalledWith(grammar, rules, 1);
     expect(mockGraph.add).toHaveBeenCalledWith(initialString);
     expect(ParseState).toHaveBeenCalledWith(mockGraph, 'foo');
+  });
+
+  test('it builds parse state with a GBNF Rule as input', () => {
+    const grammar = _`"foo"`;
+    const initialString = 'foo';
+    const symbolIds = new Map();
+    symbolIds.set('root', 1);
+    const rules: InternalRuleDef[][] = [
+      [{ type: InternalRuleType.END }],
+      [{ type: InternalRuleType.CHAR, value: [97] }],
+    ];
+    vi.mocked(RulesBuilder).mockImplementation(() => {
+      class MockRulesBuilder {
+        rules = rules;
+        symbolIds = symbolIds;
+      }
+      return new MockRulesBuilder() as unknown as RulesBuilder;
+    });
+    class MockGraph { add = vi.fn().mockImplementation(() => 'foo') }
+    const mockGraph = new MockGraph();
+    vi.mocked(Graph).mockImplementation(() => mockGraph as unknown as Graph);
+    class MockParseState { }
+    const mockParseState = new MockParseState();
+    vi.mocked(ParseState).mockImplementation(() => mockParseState as ParseState);
+    vi.mocked(buildRuleStack).mockImplementation((rules) => rules as any);
+
+    expect(GBNF(grammar, initialString)).toEqual(mockParseState);
+    expect(Graph).toHaveBeenCalledWith(grammar.compile(), rules, 1);
   });
 });

--- a/packages/gbnf/javascript/src/gbnf.ts
+++ b/packages/gbnf/javascript/src/gbnf.ts
@@ -2,10 +2,15 @@ import { GrammarParseError, } from "./utils/errors.js";
 import { buildRuleStack, } from "./grammar-parser/build-rule-stack.js";
 import { Graph, } from "./grammar-graph/graph.js";
 import { ParseState, } from "./grammar-graph/parse-state.js";
-import { UnresolvedRule, ValidInput, } from "./grammar-graph/types.js";
+import {
+  UnresolvedRule,
+  ValidInput,
+} from "./grammar-graph/types.js";
 import { RulesBuilder, } from "./rules-builder/index.js";
+import { GBNFRule, } from "./builder/gbnf-rule.js";
 
-export const GBNF = (grammar: string, initialString: ValidInput = ''): ParseState => {
+export const GBNF = (input: string | GBNFRule, initialString: ValidInput = ''): ParseState => {
+  const grammar = typeof input === 'string' ? input : input.compile();
   const { rules, symbolIds, } = new RulesBuilder(grammar);
   if (rules.length === 0) {
     throw new GrammarParseError(grammar, 0, 'No rules were found');


### PR DESCRIPTION
`gbnf` should be able to accept a `GBNFRule` as an input, so you can do:

```
gbnf(_`"foo"`)
```

And it will automatically compile it to a grammar for you.